### PR TITLE
Feature/cxx11 adaption

### DIFF
--- a/art/Framework/Core/CachedProducts.cc
+++ b/art/Framework/Core/CachedProducts.cc
@@ -70,7 +70,7 @@ wantEvent(Event const& ev)
 
   return any_of(begin(p_and_e_selectors_),
                 end(p_and_e_selectors_),
-                [](auto& s) { return s.match(); });
+                [](decltype(p_and_e_selectors_)::value_type & s) { return s.match(); });
 }
 
 art::Handle<art::TriggerResults>
@@ -96,7 +96,7 @@ getOneTriggerResults(Event const& ev) const
 void
 CachedProducts::
 clearTriggerResults() {
-  for_all(p_and_e_selectors_, [](auto& p) { p.clearTriggerResults(); });
+  for_all(p_and_e_selectors_, [](decltype(p_and_e_selectors_)::value_type & p) { p.clearTriggerResults(); });
   loadDone_ = false;
   numberFound_ = 0;
 }
@@ -112,7 +112,7 @@ loadTriggerResults(Event const& ev)
   // Note: The loadTriggerResults call might throw,
   // so numberFound_ may be less than expected.
   for_all(p_and_e_selectors_,
-          [&,this](auto& s){ s.loadTriggerResults(ev); ++numberFound_;});
+          [&,this](decltype(p_and_e_selectors_)::value_type & s){ s.loadTriggerResults(ev); ++numberFound_;});
 }
 
 

--- a/art/Framework/Core/EndPathExecutor.cc
+++ b/art/Framework/Core/EndPathExecutor.cc
@@ -33,7 +33,7 @@ bool art::EndPathExecutor::terminate() const
                                        // returns true if range is empty.
     std::all_of(outputWorkers_.cbegin(),
                 outputWorkers_.cend(),
-                [](auto& w){ return w->limitReached(); });
+                [](decltype(outputWorkers_)::value_type w){ return w->limitReached(); });
   if (rc) {
     mf::LogInfo("SuccessfulTermination")
       << "The job is terminating successfully because each output module\n"
@@ -96,44 +96,44 @@ void art::EndPathExecutor::openOutputFiles(FileBlock & fb)
 
 void art::EndPathExecutor::writeRun(RunPrincipal const & rp)
 {
-  doForAllEnabledOutputWorkers_([&rp](auto w){ w->writeRun(rp); });
+  doForAllEnabledOutputWorkers_([&rp](OutputWorker* w){ w->writeRun(rp); });
 }
 
 void art::EndPathExecutor::writeSubRun(SubRunPrincipal const & srp)
 {
-  doForAllEnabledOutputWorkers_([&srp](auto w){ w->writeSubRun(srp); });
+  doForAllEnabledOutputWorkers_([&srp](OutputWorker* w){ w->writeSubRun(srp); });
 }
 
 bool art::EndPathExecutor::shouldWeCloseOutput() const
 {
   return std::any_of(outputWorkers_.cbegin(),
                      outputWorkers_.cend(),
-                     [](auto& w){ return w->shouldWeCloseFile(); });
+                     [](decltype(outputWorkers_)::value_type w){ return w->shouldWeCloseFile(); });
 }
 
 void art::EndPathExecutor::respondToOpenInputFile(FileBlock const & fb)
 {
-  doForAllEnabledWorkers_([&fb](auto w){ w->respondToOpenInputFile(fb); });
+  doForAllEnabledWorkers_([&fb](Worker* w){ w->respondToOpenInputFile(fb); });
 }
 
 void art::EndPathExecutor::respondToCloseInputFile(FileBlock const & fb)
 {
-  doForAllEnabledWorkers_([&fb](auto w){ w->respondToCloseInputFile(fb); });
+  doForAllEnabledWorkers_([&fb](Worker* w){ w->respondToCloseInputFile(fb); });
 }
 
 void art::EndPathExecutor::respondToOpenOutputFiles(FileBlock const & fb)
 {
-  doForAllEnabledWorkers_([&fb](auto w){ w->respondToOpenOutputFiles(fb); });
+  doForAllEnabledWorkers_([&fb](Worker* w){ w->respondToOpenOutputFiles(fb); });
 }
 
 void art::EndPathExecutor::respondToCloseOutputFiles(FileBlock const & fb)
 {
-  doForAllEnabledWorkers_([&fb](auto w){ w->respondToCloseOutputFiles(fb); });
+  doForAllEnabledWorkers_([&fb](Worker* w){ w->respondToCloseOutputFiles(fb); });
 }
 
 void art::EndPathExecutor::beginJob()
 {
-  doForAllEnabledWorkers_([](auto w){ w->beginJob(); });
+  doForAllEnabledWorkers_([](Worker* w){ w->beginJob(); });
 }
 
 bool
@@ -173,5 +173,5 @@ setEndPathModuleEnabled(std::string const & label, bool enable)
 void
 art::EndPathExecutor::resetAll()
 {
-  doForAllEnabledWorkers_([](auto w){ w->reset(); });
+  doForAllEnabledWorkers_([](Worker* w){ w->reset(); });
 }

--- a/art/Framework/Core/OutputModule.cc
+++ b/art/Framework/Core/OutputModule.cc
@@ -118,7 +118,7 @@ doBeginJob()
 {
   selectProducts();
   beginJob();
-  cet::for_all(plugins_, [](auto& p){ p->doBeginJob(); });
+  cet::for_all(plugins_, [](decltype(plugins_)::value_type& p){ p->doBeginJob(); });
 }
 
 void
@@ -126,7 +126,7 @@ art::OutputModule::
 doEndJob()
 {
   endJob();
-  cet::for_all(plugins_, [](auto& p){ p->doEndJob(); });
+  cet::for_all(plugins_, [](decltype(plugins_)::value_type& p){ p->doEndJob(); });
 }
 
 
@@ -152,7 +152,7 @@ doEvent(EventPrincipal const & ep,
                        ep.id(),
                        trRef);
     // ... and invoke the plugins:
-    cet::for_all(plugins_, [&e](auto& p){ p->doCollectMetadata(e); });
+    cet::for_all(plugins_, [&e](decltype(plugins_)::value_type& p){ p->doCollectMetadata(e); });
     // Finish.
     updateBranchParents(ep);
     if (remainingEvents_ > 0) {
@@ -171,7 +171,7 @@ doBeginRun(RunPrincipal const & rp,
   FDEBUG(2) << "beginRun called\n";
   beginRun(rp);
   Run const r(const_cast<RunPrincipal &>(rp), moduleDescription_);
-  cet::for_all(plugins_, [&r](auto& p){ p->doBeginRun(r); });
+  cet::for_all(plugins_, [&r](decltype(plugins_)::value_type& p){ p->doBeginRun(r); });
   return true;
 }
 
@@ -184,7 +184,7 @@ doEndRun(RunPrincipal const & rp,
   FDEBUG(2) << "endRun called\n";
   endRun(rp);
   Run const r(const_cast<RunPrincipal &>(rp), moduleDescription_);
-  cet::for_all(plugins_, [&r](auto& p){ p->doEndRun(r); });
+  cet::for_all(plugins_, [&r](decltype(plugins_)::value_type& p){ p->doEndRun(r); });
   return true;
 }
 
@@ -205,7 +205,7 @@ doBeginSubRun(SubRunPrincipal const & srp,
   FDEBUG(2) << "beginSubRun called\n";
   beginSubRun(srp);
   SubRun const sr(const_cast<SubRunPrincipal &>(srp), moduleDescription_);
-  cet::for_all(plugins_, [&sr](auto& p){ p->doBeginSubRun(sr); });
+  cet::for_all(plugins_, [&sr](decltype(plugins_)::value_type& p){ p->doBeginSubRun(sr); });
   return true;
 }
 
@@ -218,7 +218,7 @@ doEndSubRun(SubRunPrincipal const & srp,
   FDEBUG(2) << "endSubRun called\n";
   endSubRun(srp);
   SubRun const sr(const_cast<SubRunPrincipal &>(srp), moduleDescription_);
-  cet::for_all(plugins_, [&sr](auto& p){ p->doEndSubRun(sr); });
+  cet::for_all(plugins_, [&sr](decltype(plugins_)::value_type& p){ p->doEndSubRun(sr); });
   return true;
 }
 

--- a/art/Framework/Core/Path.cc
+++ b/art/Framework/Core/Path.cc
@@ -97,7 +97,7 @@ namespace art {
   void
   Path::clearCounters() {
     timesRun_ = timesPassed_ = timesFailed_ = timesExcept_ = 0;
-    for_all(workers_, [](auto& w) { w.clearCounters(); });
+    for_all(workers_, [](decltype(workers_)::value_type& w) { w.clearCounters(); });
   }
 
    void Path::findEventModifiers(std::vector<std::string> &foundLabels) const {

--- a/art/Framework/Core/PathManager.cc
+++ b/art/Framework/Core/PathManager.cc
@@ -148,7 +148,7 @@ art::detail::ModuleConfigInfoMap
 art::PathManager::
 fillAllModules_()
 {
-  static ParameterSet const empty;
+  static ParameterSet const empty = ParameterSet();
   detail::ModuleConfigInfoMap all_modules;
   std::ostringstream error_stream;
   for (auto const & pathRootName :

--- a/art/Framework/Core/ProductRegistryHelper.cc
+++ b/art/Framework/Core/ProductRegistryHelper.cc
@@ -57,7 +57,7 @@ registerProducts(MasterProductRegistry& preg,
     productList_.reset();
   }
   cet::for_all(typeLabelList_,
-	       [&, this](auto const& tl){ addToRegistry(tl, md, preg); });
+	       [&, this](decltype(typeLabelList_)::value_type const& tl){ addToRegistry(tl, md, preg); });
 }
 
 art::TypeLabel const &

--- a/art/Framework/Core/PtrRemapper.h
+++ b/art/Framework/Core/PtrRemapper.h
@@ -441,7 +441,7 @@ operator()(std::vector<PROD const *> const &in,
   this->operator()<CONT>(in,
                          out,
                          offsets,
-                         [&x](auto& elem){ elem.extractor(x); }); // 10?
+                         [&x](typename decltype(in)::value_type& elem){ elem.extractor(x); }); // 10?
 }
 
 // 9.
@@ -456,7 +456,7 @@ operator()(std::vector<PROD const *> const &in,
   this->operator()<CONT>(in,
                          out,
                          offsets,
-       [&x](auto& elem){ elem.extractor(x); }); // 10.
+       [&x](typename decltype(in)::value_type& elem){ elem.extractor(x); }); // 10.
 }
 
 // 10.

--- a/art/Framework/Core/Schedule.cc
+++ b/art/Framework/Core/Schedule.cc
@@ -96,28 +96,28 @@ void
 art::Schedule::
 respondToOpenInputFile(FileBlock const & fb)
 {
-  doForAllWorkers_([&fb](auto w){ w->respondToOpenInputFile(fb); });
+  doForAllWorkers_([&fb](Worker* w){ w->respondToOpenInputFile(fb); });
 }
 
 void
 art::Schedule::
 respondToCloseInputFile(FileBlock const & fb)
 {
-  doForAllWorkers_([&fb](auto w){ w->respondToCloseInputFile(fb); });
+  doForAllWorkers_([&fb](Worker* w){ w->respondToCloseInputFile(fb); });
 }
 
 void
 art::Schedule::
 respondToOpenOutputFiles(FileBlock const & fb)
 {
-  doForAllWorkers_([&fb](auto w){ w->respondToOpenOutputFiles(fb); });
+  doForAllWorkers_([&fb](Worker* w){ w->respondToOpenOutputFiles(fb); });
 }
 
 void
 art::Schedule::
 respondToCloseOutputFiles(FileBlock const & fb)
 {
-  doForAllWorkers_([&fb](auto w){ w->respondToCloseOutputFiles(fb); });
+  doForAllWorkers_([&fb](Worker* w){ w->respondToCloseOutputFiles(fb); });
 }
 
 bool
@@ -153,14 +153,14 @@ void
 art::Schedule::
 beginJob()
 {
-  doForAllWorkers_([](auto w){ w->beginJob(); });
+  doForAllWorkers_([](Worker* w){ w->beginJob(); });
 }
 
 void
 art::Schedule::
 resetAll_()
 {
-  doForAllWorkers_([](auto w){ w->reset(); });
+  doForAllWorkers_([](Worker* w){ w->reset(); });
   triggerPathsInfo_.pathResults().reset();
 }
 

--- a/art/Framework/Core/Schedule.h
+++ b/art/Framework/Core/Schedule.h
@@ -176,7 +176,7 @@ inline
 bool
 art::Schedule::runTriggerPaths_(typename T::MyPrincipal & ep)
 {
-  doForAllEnabledPaths_([&ep](auto p){ p->processOneOccurrence<T>(ep); });
+  doForAllEnabledPaths_([&ep](Path* p){ p->processOneOccurrence<T>(ep); });
   return triggerPathsInfo_.pathResults().accept();
 }
 

--- a/art/Framework/EventProcessor/EventProcessor.cc
+++ b/art/Framework/EventProcessor/EventProcessor.cc
@@ -40,8 +40,13 @@
 #include <iostream>
 #include <string>
 #include <vector>
-
 using fhicl::ParameterSet;
+
+template<typename T, typename ...Args>
+std::unique_ptr<T> make_unique( Args&& ...args )
+{
+    return std::unique_ptr<T>( new T( std::forward<Args>(args)... ) );
+}
 
 namespace {
   // Most signals.
@@ -302,13 +307,13 @@ initServices_(ParameterSet const & top_pset,
   ServiceDirector director(std::move(services), areg, token);
 
   // Services requiring special construction.
-  director.addSystemService(std::make_unique<CurrentModule>(areg));
-  director.addSystemService(std::make_unique<TriggerNamesService>
+  director.addSystemService(::make_unique<CurrentModule>(areg));
+  director.addSystemService(::make_unique<TriggerNamesService>
                             (top_pset, pathManager_.triggerPathNames()));
-  director.addSystemService(std::make_unique<FloatingPointControl>(fpc_pset, areg));
-  director.addSystemService(std::make_unique<ScheduleContext>());
+  director.addSystemService(::make_unique<FloatingPointControl>(fpc_pset, areg));
+  director.addSystemService(::make_unique<ScheduleContext>());
   if (!pathSelection.is_empty()) {
-    director.addSystemService(std::make_unique<PathSelection>(*this));
+    director.addSystemService(::make_unique<PathSelection>(*this));
   }
   return std::move(director);
 }

--- a/art/Framework/IO/ProductMix/MixHelper.cc
+++ b/art/Framework/IO/ProductMix/MixHelper.cc
@@ -234,7 +234,7 @@ art::MixHelper::mixAndPut(EntryNumberSequence const & enSeq,
   ptpBuilder_.populateRemapper(ptrRemapper_, e);
   // Do the branch-wise read, mix and put.
   cet::for_all(mixOps_,
-	       [&,this](auto const& op){ this->mixAndPutOne_(op, enSeq, e); });
+	       [&,this](decltype(mixOps_)::value_type const& op){ this->mixAndPutOne_(op, enSeq, e); });
   nEventsReadThisFile_ += enSeq.size();
   totalEventsRead_ += enSeq.size();
 }

--- a/art/Framework/Services/Optional/RandomNumberGenerator_service.cc
+++ b/art/Framework/Services/Optional/RandomNumberGenerator_service.cc
@@ -84,7 +84,7 @@ namespace {
   bool         const  DEFAULT_DEBUG_VALUE( false );
   int          const  DEFAULT_NPRINT_VALUE( 10 );
   ParameterSet const  DEFAULT_PSET
-#if (__GNUC__ == 4 && __GNUC_MINOR__ == 6) || defined __ICC && __INTEL_COMPILER_BUILD_DATE <= 20140120
+#if (__GNUC__ == 4 && __GNUC_MINOR__ == 6) || (defined __ICC && __INTEL_COMPILER_BUILD_DATE <= 20140120)  || defined __clang__
  // Required by C++03 & C++2011; GCC v4.6 became more strict. ISO agreed
  // to relax.
   = ParameterSet()

--- a/art/Framework/Services/Optional/detail/constrained_multimap.h
+++ b/art/Framework/Services/Optional/detail/constrained_multimap.h
@@ -24,16 +24,16 @@ namespace art {
 
       using multimap_type = std::multimap<ARGS...>;
 
-      auto begin  () const { return map_.begin  (); }
-      auto end    () const { return map_.end    (); }
-      auto cbegin () const { return map_.cbegin (); }
-      auto cend   () const { return map_.cend   (); }
-      auto crbegin() const { return map_.crbegin(); }
-      auto crend  () const { return map_.crend  (); }
+      auto begin  () const -> typename multimap_type::const_iterator { return map_.begin  (); }
+      auto end    () const -> typename multimap_type::const_iterator { return map_.end    (); }
+      auto cbegin () const -> typename multimap_type::const_iterator  { return map_.cbegin (); }
+      auto cend   () const -> typename multimap_type::const_iterator  { return map_.cend   (); }
+      auto crbegin() const -> typename multimap_type::const_reverse_iterator { return map_.crbegin(); }
+      auto crend  () const -> typename multimap_type::const_reverse_iterator { return map_.crend  (); }
 
-      auto empty() const { return map_.empty(); }
-      auto size () const { return map_.size (); }
-      auto unique_key_limit() const { return SIZE_LIMIT; }
+      bool empty() const { return map_.empty(); }
+      size_t size () const { return map_.size (); }
+      unsigned unique_key_limit() const { return SIZE_LIMIT; }
       void erase( typename multimap_type::const_iterator iter ) { map_.erase(iter); }
 
       using key_type    = typename multimap_type::key_type;

--- a/art/Framework/Services/Registry/detail/ServiceCache.h
+++ b/art/Framework/Services/Registry/detail/ServiceCache.h
@@ -4,13 +4,14 @@
 #include "art/Utilities/TypeID.h"
 
 #include <map>
+#include "boost/container/map.hpp"
 
 namespace art {
   namespace detail {
     class ServiceCacheEntry;
 
-    typedef  std::map< TypeID, detail::ServiceCacheEntry >  ServiceCache;
-
+    //typedef  std::map< TypeID, detail::ServiceCacheEntry >  ServiceCache;
+    typedef boost::container::map<TypeID, detail::ServiceCacheEntry> ServiceCache;
   }
 
 }

--- a/art/Ntuple/sqlite_helpers.cc
+++ b/art/Ntuple/sqlite_helpers.cc
@@ -94,40 +94,40 @@ namespace sqlite
   //=======================================================================
   void deleteTable( sqlite3* db, std::string const& tname )
   {
-    exec( db, "delete from "s + tname );
+    exec( db, std::string("delete from ") + tname );
   }
 
   void dropTable( sqlite3* db, std::string const& tname )
   {
-    exec( db, "drop table "s+ tname );
+    exec( db, std::string("drop table ") + tname );
   }
 
   //=======================================================================
   // Statistics helpers
 
   double mean( sqlite3* db, const std::string& tname, const std::string& colname ){
-    return query_db<double>( db, "select avg("s+colname+") from "s + tname );
+    return query_db<double>( db, std::string("select avg(")+colname+std::string(") from ") + tname );
   }
 
   double median( sqlite3* db, const std::string& tname, const std::string& colname ){
     return query_db<double>( db,
-                             "select avg("s+colname+")"s+
-                             " from (select "s+colname+
-                             " from "s+tname+
-                             " order by "s+colname+
-                             " limit 2 - (select count(*) from "s + tname+") % 2"s+
-                             " offset (select (count(*) - 1) / 2"s+
-                             " from "s + tname+"))"s );
+                             std::string("select avg(")+colname+std::string(")")+
+                             std::string(" from (select ")+colname+
+                             std::string(" from ")+tname+
+                             std::string(" order by ")+colname+
+                             std::string(" limit 2 - (select count(*) from ") + tname+std::string(") % 2")+
+                             std::string(" offset (select (count(*) - 1) / 2")+
+                             std::string(" from ") + tname+ std::string("))") );
   }
 
   double rms( sqlite3* db, const std::string& tname, const std::string& colname ){
     double const ms = query_db<double>( db,
-                                        "select sum("s+
-                                        "("s + colname + "-(select avg("s + colname + ") from "s + tname +"))"s +
-                                        "*"s +
-                                        "("s + colname + "-(select avg("s + colname + ") from "s + tname +"))"s +
-                                        " ) /"s +
-                                        "(count("s + colname +")) from "s + tname );
+                                        std::string("select sum(")+
+                                        std::string("(") + colname + std::string("-(select avg(") + colname + std::string(") from ") + tname + std::string("))") +
+                                        std::string("*") +
+                                        std::string("(") + colname + std::string("-(select avg(") + colname + std::string(") from ") + tname + std::string("))") +
+                                        std::string(" ) /") +
+                                        std::string("(count(") + colname +std::string(")) from ") + tname );
     return std::sqrt( ms );
   }
 

--- a/art/Ntuple/sqlite_helpers.h
+++ b/art/Ntuple/sqlite_helpers.h
@@ -16,7 +16,7 @@
 #include "art/Ntuple/sqlite_stringstream.h"
 #include "art/Utilities/Exception.h"
 
-using namespace std::string_literals;
+//using namespace std::string_literals;
 
 namespace sqlite
 {
@@ -99,7 +99,7 @@ namespace sqlite
                                 IT beginCol,
                                 IT endCol)
     {
-      std::string ddl("CREATE TABLE "s + tname + " ( "s);
+      std::string ddl(std::string("CREATE TABLE ") + tname + std::string(" ( "));
       BuildSQL<TUP, std::tuple_size<TUP>::value-1>::addMore(ddl, beginCol, endCol);
       ddl += " )";
       return ddl;
@@ -178,7 +178,7 @@ namespace sqlite
   }
 
   template<typename T>
-  decltype(auto) query_db(sqlite3* db, std::string const& ddl, bool const do_throw = true)
+  T query_db(sqlite3* db, std::string const& ddl, bool const do_throw = true)
   {
     detail::query_result res = detail::query( db, ddl );
     if ( res.data.empty() && do_throw ) throw art::Exception(art::errors::SQLExecutionError,"sqlite query_db unsuccessful");
@@ -186,8 +186,8 @@ namespace sqlite
   }
 
   template<typename T>
-  auto getUniqueEntries( sqlite3* db, const std::string& tname, const std::string& colname ) {
-    return query_db<std::vector<T>>( db, "select distinct "s+colname+" from "s+tname );
+  std::vector<T> getUniqueEntries( sqlite3* db, const std::string& tname, const std::string& colname ) {
+    return query_db<std::vector<T>>( db, std::string("select distinct ")+colname+std::string(" from ")+tname );
   }
 
   //=====================================================================
@@ -209,7 +209,7 @@ namespace sqlite
         deleteTable( db, tname );
       }
 
-      rowid = query_db<uint32_t>( db, "select count(*) from "s + tname );
+      rowid = query_db<uint32_t>( db, std::string("select count(*) from ") + tname );
 
     }
   }
@@ -219,12 +219,12 @@ namespace sqlite
 
   template<typename T = double>
   T min( sqlite3* db, const std::string& tname, const std::string& colname ) {
-    return query_db<T>( db, "select min("s+colname+") from "s + tname );
+    return query_db<T>( db, std::string("select min(")+colname+std::string(") from ") + tname );
   }
 
   template<typename T = double>
   T max( sqlite3* db, const std::string& tname, const std::string& colname ) {
-    return query_db<T>( db, "select max("s+colname+") from "s + tname );
+    return query_db<T>( db, std::string("select max(")+colname+std::string(") from ") + tname );
   }
 
   double mean  ( sqlite3* db, std::string const& tname, std::string const& colname );

--- a/art/Ntuple/sqlite_mfPlugin.cc
+++ b/art/Ntuple/sqlite_mfPlugin.cc
@@ -7,7 +7,11 @@
 
 #include <cstdint>
 #include <memory>
-
+template<typename T, typename ...Args>
+std::unique_ptr<T> make_unique( Args&& ...args )
+{
+    return std::unique_ptr<T>( new T( std::forward<Args>(args)... ) );
+}
 namespace sqlite {
 
   using std::string;
@@ -88,10 +92,10 @@ namespace sqlite {
 
 extern "C" {
 
-  auto makePlugin( const std::string&,
+  std::unique_ptr<sqlite::sqlite3Plugin> makePlugin( const std::string&,
                    const fhicl::ParameterSet& pset) {
 
-    return std::make_unique<sqlite::sqlite3Plugin>( pset );
+    return ::make_unique<sqlite::sqlite3Plugin>( pset );
 
   }
 

--- a/art/Ntuple/sqlite_stringstream.h
+++ b/art/Ntuple/sqlite_stringstream.h
@@ -71,7 +71,7 @@ namespace sqlite {
     // Inserters
 
     template< typename T>
-    auto convertTo( std::string const & arg ) {
+    T convertTo( std::string const & arg ) {
       return arg;
     }
 
@@ -101,15 +101,15 @@ namespace sqlite {
 
   };
 
-  template<> inline auto stringstream::convertTo<int               >( std::string const & arg ) { return std::stoi  ( arg ); }
-  template<> inline auto stringstream::convertTo<long              >( std::string const & arg ) { return std::stol  ( arg ); }
-  template<> inline auto stringstream::convertTo<long long         >( std::string const & arg ) { return std::stoll ( arg ); }
-  template<> inline auto stringstream::convertTo<unsigned          >( std::string const & arg ) { return std::stoul ( arg ); }
-  template<> inline auto stringstream::convertTo<unsigned long     >( std::string const & arg ) { return std::stoul ( arg ); }
-  template<> inline auto stringstream::convertTo<unsigned long long>( std::string const & arg ) { return std::stoull( arg ); }
-  template<> inline auto stringstream::convertTo<float             >( std::string const & arg ) { return std::stof  ( arg ); }
-  template<> inline auto stringstream::convertTo<double            >( std::string const & arg ) { return std::stod  ( arg ); }
-  template<> inline auto stringstream::convertTo<long double       >( std::string const & arg ) { return std::stold ( arg ); }
+  template<> inline int stringstream::convertTo<int               >( std::string const & arg ) { return std::stoi  ( arg ); }
+  template<> inline long stringstream::convertTo<long              >( std::string const & arg ) { return std::stol  ( arg ); }
+  template<> inline long long stringstream::convertTo<long long         >( std::string const & arg ) { return std::stoll ( arg ); }
+  template<> inline unsigned stringstream::convertTo<unsigned          >( std::string const & arg ) { return std::stoul ( arg ); }
+  template<> inline unsigned long stringstream::convertTo<unsigned long     >( std::string const & arg ) { return std::stoul ( arg ); }
+  template<> inline unsigned long long stringstream::convertTo<unsigned long long>( std::string const & arg ) { return std::stoull( arg ); }
+  template<> inline float stringstream::convertTo<float             >( std::string const & arg ) { return std::stof  ( arg ); }
+  template<> inline double stringstream::convertTo<double            >( std::string const & arg ) { return std::stod  ( arg ); }
+  template<> inline long double stringstream::convertTo<long double       >( std::string const & arg ) { return std::stold ( arg ); }
 
 } // namespace sqlite
 

--- a/art/Persistency/Common/CollectionUtilities.h
+++ b/art/Persistency/Common/CollectionUtilities.h
@@ -194,8 +194,8 @@ template <typename iterator>
 bool
 art::detail::verifyPtrCollection(iterator beg,
                                  iterator end,
-                                 art::ProductID id = art::ProductID(),
-                                 art::EDProductGetter const *getter = 0) {
+                                 art::ProductID id /*= art::ProductID()*/,
+                                 art::EDProductGetter const *getter /*= 0*/) {
   if (beg == end) return true;
   if (!id.isValid()) {
     id = (*beg).id();

--- a/test/Framework/Services/Registry/GlobalSignal_t.cc
+++ b/test/Framework/Services/Registry/GlobalSignal_t.cc
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(TestSignal1_t)
   TestSignal1 s;
   std::string const test_text { "Test text" };
   boost::test_tools::output_test_stream os;
-  s.watch([&test_text](auto& x){ testCallback<0>(x, test_text); });
+  s.watch([&test_text](std::ostream& x){ testCallback<0>(x, test_text); });
   BOOST_CHECK_NO_THROW(s.invoke(os));
   BOOST_CHECK(os.is_equal(test_text));
 }

--- a/test/Framework/Services/Registry/LocalSignal_t.cc
+++ b/test/Framework/Services/Registry/LocalSignal_t.cc
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(TestSignal1_t)
   std::string const test_text { "Test text" };
   boost::test_tools::output_test_stream os;
   BOOST_CHECK_NO_THROW(s.watch(sID,
-                               [&test_text](auto& x){ testCallback<0>(x, test_text); }));
+                               [&test_text](std::ostream& x){ testCallback<0>(x, test_text); }));
   BOOST_CHECK_NO_THROW(s.invoke(sID, os));
   BOOST_CHECK(os.is_equal(test_text));
 }
@@ -159,7 +159,7 @@ BOOST_AUTO_TEST_CASE(TestSignal1_All_t)
   TestSignal1 s(nSchedules);
   std::string const test_text { "Test text" };
   boost::test_tools::output_test_stream os;
-  BOOST_CHECK_NO_THROW(s.watchAll([&test_text](auto& x){
+  BOOST_CHECK_NO_THROW(s.watchAll([&test_text](std::ostream& x){
         testCallback<0>(x, test_text);
       }));
   BOOST_CHECK_NO_THROW(s.invoke(sID, os));

--- a/test/Ntuple/sqlite_stringstream_t.cc
+++ b/test/Ntuple/sqlite_stringstream_t.cc
@@ -3,16 +3,14 @@
 
 #include <string>
 
-using namespace std::string_literals;
-using namespace sqlite;
 
 int main() {
 
-  stringstream ss;
+  sqlite::stringstream ss;
 
   // put a few things in
   ss << "const char*"
-     << "std::string"s
+     << std::string("std::string")
      << 1
      << 2.4
      << 3.6f;


### PR DESCRIPTION
Demonstrates minimal changes needed to support C++11 only build of current Art release.

Some features, such as string literals, may be backportable. All currently built tests pass on Linux, testing is needed on Clang.

Clang support is primary reason for backporting to C++11 in order to generate correct debugging information. Whilst this is a deficiency/bug in Clang, this pull request shows how little C++14 is actually required. There are no performance numbers yet to indicate any changes.
